### PR TITLE
Fix windows path seperator for templates

### DIFF
--- a/lib/inflectStream.js
+++ b/lib/inflectStream.js
@@ -17,6 +17,7 @@ module.exports = function (options) {
       cat: inf.cat,
       isTemplate: (inf.cat === 'template')
     });
+    
     next();
   });
 };


### PR DESCRIPTION
`rmExt` contained code to fix path separators, but it wasn't being used for templates. This fixes the path separators specifically for templates.

Having this in two places isn't a great idea, but neither is fixing path separators in a function that claims it's only removing file extensions.
